### PR TITLE
fix crash in el8 due to vector reserve

### DIFF
--- a/src/multiuser.cpp
+++ b/src/multiuser.cpp
@@ -146,8 +146,7 @@ public:
         // TODO: cache the lot of this.
         int buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
         if (buflen < 0) {buflen = 16384;}
-        std::vector<char> buf;
-        buf.resize(buflen);
+        std::vector<char> buf(buflen);
 
         int retval;
         do {

--- a/src/multiuser.cpp
+++ b/src/multiuser.cpp
@@ -147,14 +147,14 @@ public:
         int buflen = sysconf(_SC_GETPW_R_SIZE_MAX);
         if (buflen < 0) {buflen = 16384;}
         std::vector<char> buf;
-        buf.reserve(buflen);
+        buf.resize(buflen);
 
         int retval;
         do {
             retval = getpwnam_r(client->name, &pwd, &buf[0], buflen, &result);
             if ((result == nullptr) && (retval == ERANGE)) {
                 buflen *= 2;
-                buf.reserve(buflen);
+                buf.resize(buflen);
                 continue;
             }
             break;


### PR DESCRIPTION
When using reserve for allocating memory in a vector, the size of the vector (meaning the number of elements in the vector) remains as 0. Then when the we use the "[]" operator (line 154) a new assert, introduced in el8, is done to verify that the vector isn't empty and given that it is empty the execution exits with the following error[*].

This can be fixed by using "resize" instead of "reserve" which apart from allocating memory, it sets a default value, thus affecting the size of the vector.

[*]
/usr/include/c++/8/bits/stl_vector.h:932: std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp = char; _Alloc = std::allocator<char>; std::vector<_Tp, _Alloc>::reference = char&; std::vector<_Tp, _Alloc>::size_type = long unsigned int]: Assertion '__builtin_expect(__n < this->size(), true)' failed.