### PR TITLE
Obtain username from passed environment when SecEntity object not pas…

### DIFF
--- a/src/multiuser.cpp
+++ b/src/multiuser.cpp
@@ -572,7 +572,15 @@ public:
                  XrdOucErrInfo &eInfo,
            const XrdSecEntity  *client = 0,
            const char          *opaque = 0) override {
-        UserSentry sentry(client, m_log, m_authz.get(), opaque, path);
+
+        const XrdSecEntity *entP;
+              XrdSecEntity  myEntity;
+              XrdOucEnv    *envP;
+
+        if (!(entP = client) && (envP = eInfo.getEnv())
+        &&  (myEntity.name = envP->Get("request.name"))) entP = &myEntity;
+
+        UserSentry sentry(entP, m_log, m_authz.get(), opaque, path);
         return m_sfs->chksum(Func, csName, path, eInfo , client, opaque);
     }
 


### PR DESCRIPTION
Added code to replace missing SecEntity object when chksum() is called in the background with the associated username as indicated by the passed environment. This patch will only work when used in conjunction with a patched xrootd that sets up the environment. If used with older xrootd releases it essentially becomes a no-op and the chksum() will fail like it always has. Hence, this patch is benign in any context that it doesn't understand.