### PR TITLE
Initialize crc32

### DIFF
--- a/src/XrdChecksumCalc.cc
+++ b/src/XrdChecksumCalc.cc
@@ -95,6 +95,7 @@ human_readable_evp(const unsigned char *evp, size_t length)
 ChecksumState::ChecksumState(unsigned digests)
     : m_digests(digests),
       m_cksum(0),
+      m_crc32(crc32(0, NULL, 0)),
       m_adler32(adler32(0, NULL, 0)),
       m_md5_length(0),
       m_cur_chunk_bytes(0),


### PR DESCRIPTION
```
==456247== Use of uninitialised value of size 8
==456247==    at 0x724CE34: ??? (in /usr/lib64/libz.so.1.2.11)
==456247==    by 0x116A159F: ChecksumState::Update(unsigned char const*, unsigned long) (XrdChecksumCalc.cc:189)
==456247==    by 0x1168DF21: MultiuserFile::Write(void const*, long, unsigned long) (multiuser.cpp:127)
==456247==    by 0x4EC4A92: XrdOfsFile::write(long long, char const*, int) (XrdOfs.cc:1466)
==456247==    by 0x4EB37E5: XrdXrootdProtocol::do_WriteAll() (XrdXrootdXeq.cc:3128)
==456247==    by 0x4EB3E97: XrdXrootdProtocol::do_Write() (XrdXrootdXeq.cc:3071)
==456247==    by 0x4EA792F: XrdXrootdProtocol::Process2() (XrdXrootdProtocol.cc:485)
==456247==    by 0x520D27F: DoIt (XrdLinkXeq.cc:320)
==456247==    by 0x520D27F: XrdLinkXeq::DoIt() (XrdLinkXeq.cc:308)
==456247==    by 0x5209BD1: XrdLink::setProtocol(XrdProtocol*, bool, bool) (XrdLink.cc:435)
==456247==    by 0x52101A6: XrdScheduler::Run() (XrdScheduler.cc:406)
==456247==    by 0x52102C8: XrdStartWorking(void*) (XrdScheduler.cc:89)
==456247==    by 0x51A0DE6: XrdSysThread_Xeq (XrdSysPthread.cc:86)
```