### PR TITLE
Fix assert in el8 due to vector reserve

### DIFF
--- a/src/XrdChecksum.cc
+++ b/src/XrdChecksum.cc
@@ -99,7 +99,7 @@ int        ChecksumManager::Calc( const char *lfn, XrdCksData &Cks, int doSet)
 
     const static int buffer_size = 256*1024;
     std::vector<char> read_buffer;
-    read_buffer.reserve(buffer_size);
+    read_buffer.resize(buffer_size);
 
     // Read through the file, checksumming as we go
     while(!is.eof()) {


### PR DESCRIPTION
We're seeing an assert triggered on [src/XrdChecksum.cc:106](https://github.com/opensciencegrid/xrootd-multiuser/blob/b89c387d18724a3b161b50f03ce9a1e78a793d8c/src/XrdChecksum.cc#L106)

I'm guessing it's asserting due to `read_buffer` being zero-length.

<details>
<summary>Backtrace</summary>

```
Core was generated by `/usr/bin/xrootd'.
Program terminated with signal SIGABRT, Aborted.
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
50        return ret;
[Current thread is 1 (Thread 0x7f037d9e0700 (LWP 957291))]

(gdb) bt
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
#1  0x00007f039df86db5 in __GI_abort () at abort.c:79
#2  0x00007f038f582a3a in std::__replacement_assert (__condition=0x7f038f585af8 "__builtin_expect(__n < this->size(), true)", __function=<synthetic pointer>, __line=932, __file=0x7f038f585b28 "/usr/include/c++/8/bits/stl_vector.h") at /usr/include/c++/8/x86_64-redhat-linux/bits/c++config.h:2391
#3  std::vector<char, std::allocator<char> >::operator[] (__n=0, this=<synthetic pointer>) at /usr/include/c++/8/bits/stl_vector.h:932
#4  ChecksumManager::Calc (this=0xfaecc0, lfn=0x12c3c10 "/store/mc/RunIISummer19UL17MiniAOD/BcToJPsiTauNu_TuneCP5_13TeV-bcvegpy2-pythia8-evtgen/MINIAODSIM/106X_mc2017_realistic_v6-v2/00000/B1FC1F74-AF1D-0241-9598-6D9DEE6186D4.root", Cks=..., doSet=<optimized out>)
    at /usr/src/debug/xrootd-multiuser-2.0.3-1.osg35up.el8.x86_64/src/XrdChecksum.cc:106
#5  0x00007f038f5767fc in MultiuserChecksum::Calc (this=0xfab9f0, Xfn=0x12c3c10 "/store/mc/RunIISummer19UL17MiniAOD/BcToJPsiTauNu_TuneCP5_13TeV-bcvegpy2-pythia8-evtgen/MINIAODSIM/106X_mc2017_realistic_v6-v2/00000/B1FC1F74-AF1D-0241-9598-6D9DEE6186D4.root", Cks=..., doSet=1)
    at /usr/src/debug/xrootd-multiuser-2.0.3-1.osg35up.el8.x86_64/src/multiuser.cpp:196
#6  0x00007f039f618ef7 in XrdOfs::chksum (this=0x7f039f899ba0 <XrdSfsGetDefaultFileSystem(XrdSfsFileSystem*, XrdSysLogger*, char const*, XrdOucEnv*)::XrdDefaultOfsFS>, Func=XrdSfsFileSystem::csCalc, csName=0x123eec0 "adler32",
    Path=0x12c3c10 "/store/mc/RunIISummer19UL17MiniAOD/BcToJPsiTauNu_TuneCP5_13TeV-bcvegpy2-pythia8-evtgen/MINIAODSIM/106X_mc2017_realistic_v6-v2/00000/B1FC1F74-AF1D-0241-9598-6D9DEE6186D4.root", einfo=..., client=0x0, opaque=0x0) at /usr/src/debug/xrootd-5.4.1-1.osg35up.el8.x86_64/xrootd/src/XrdOfs/XrdOfs.cc:1820
#7  0x00007f039f5fcfc1 in XrdXrootdProtocol::CheckSum (Stream=0x10e9b50, argv=0x7f037d9dfb40, argc=<optimized out>) at /usr/src/debug/xrootd-5.4.1-1.osg35up.el8.x86_64/xrootd/src/XrdXrootd/XrdXrootdProtocol.cc:1023
#8  0x00007f039f305c77 in XrdOucProg::Run (this=0xed0420, Sp=0x10e9b50, argV=<optimized out>, argC=4, envV=<optimized out>) at /usr/src/debug/xrootd-5.4.1-1.osg35up.el8.x86_64/xrootd/src/XrdOuc/XrdOucProg.cc:130
#9  0x00007f039f305f5e in XrdOucProg::Run (this=<optimized out>, Sp=Sp@entry=0x10e9b50, arg1=<optimized out>, arg2=<optimized out>, arg3=<optimized out>, arg4=<optimized out>) at /usr/src/debug/xrootd-5.4.1-1.osg35up.el8.x86_64/xrootd/src/XrdOuc/XrdOucProg.cc:186
#10 0x00007f039f5f4064 in XrdXrootdJob2Do::DoIt (this=0x10e9aa0) at /usr/src/debug/xrootd-5.4.1-1.osg35up.el8.x86_64/xrootd/src/XrdXrootd/XrdXrootdJob.cc:179
#11 0x00007f039f3491a7 in XrdScheduler::Run (this=0x615740 <XrdGlobal::Sched>) at /usr/src/debug/xrootd-5.4.1-1.osg35up.el8.x86_64/xrootd/src/Xrd/XrdScheduler.cc:406
#12 0x00007f039f3492c9 in XrdStartWorking (carg=<optimized out>) at /usr/src/debug/xrootd-5.4.1-1.osg35up.el8.x86_64/xrootd/src/Xrd/XrdScheduler.cc:89
#13 0x00007f039f2d9de7 in XrdSysThread_Xeq (myargs=0x7f03802e4d20) at /usr/src/debug/xrootd-5.4.1-1.osg35up.el8.x86_64/xrootd/src/XrdSys/XrdSysPthread.cc:86
#14 0x00007f039e33217a in start_thread (arg=<optimized out>) at pthread_create.c:479
#15 0x00007f039e061dc3 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```
</details>