### PR TITLE
Reorder variables to address compiler warning/error

### DIFF
--- a/src/XrdChecksum.hh
+++ b/src/XrdChecksum.hh
@@ -39,8 +39,8 @@ private:
     ChecksumState & operator=(ChecksumState const &);
 
     const unsigned m_digests;
-    uint32_t m_crc32;
     uint32_t m_cksum;
+    uint32_t m_crc32;
     uint32_t m_adler32;
 
     unsigned m_md5_length;


### PR DESCRIPTION
```
/builddir/build/BUILD/xrootd-multiuser-master/src/XrdChecksum.hh: In constructor 'ChecksumState::ChecksumState(unsigned int)':
/builddir/build/BUILD/xrootd-multiuser-master/src/XrdChecksum.hh:43:14: error: 'ChecksumState::m_cksum' will be initialized after [-Werror=reorder]
     uint32_t m_cksum;
              ^
/builddir/build/BUILD/xrootd-multiuser-master/src/XrdChecksum.hh:42:14: error:   'uint32_t ChecksumState::m_crc32' [-Werror=reorder]
     uint32_t m_crc32;
              ^
/builddir/build/BUILD/xrootd-multiuser-master/src/XrdChecksumCalc.cc:95:1: error:   when initialized here [-Werror=reorder]
 ChecksumState::ChecksumState(unsigned digests)
 ^
```