### PR TITLE
Overhaul capability setting for multiuser.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ install(
 )
 
 install(
-  FILES ${CMAKE_SOURCE_DIR}/configs/xrootd-privileged@.service
+  FILES ${CMAKE_SOURCE_DIR}/configs/xrootd-privileged@.service ${CMAKE_SOURCE_DIR}/configs/cmsd-privileged@.service
   DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/systemd/system
 )
 

--- a/configs/cmsd-privileged@.service
+++ b/configs/cmsd-privileged@.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=XRootD cmsd deamon instance %I
+Documentation=man:ccmsd(8)
+Documentation=http://xrootd.org/docs.html
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+# Note "-R xrootd" here instructs xrootd to drop privileges to the xrootd Unix user.
+ExecStart=/usr/bin/cmsd -l /var/log/xrootd/cmsd.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /var/run/xrootd/cmsd-%i.pid -n %i -R xrootd
+Type=simple
+Restart=on-abort
+RestartSec=0
+KillMode=control-group
+LimitNOFILE=65536
+WorkingDirectory=/var/spool/xrootd
+
+# These provide cmsd with the ability to override read permissions to advertise file availability.
+CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_DAC_OVERRIDE
+Capabilities=CAP_SETGID+p CAP_SETUID+p
+
+[Install]
+RequiredBy=multi-user.target

--- a/src/MultiuserDirectory.hh
+++ b/src/MultiuserDirectory.hh
@@ -24,6 +24,7 @@ public:
         //ErrorSentry err_sentry(error, m_oss->error);
         m_client = env.secEnv();
         UserSentry sentry(m_client, m_log);
+        if (!sentry.IsValid()) {return -EACCES;}
         return m_wrappedDir->Opendir(path, env);
     }
 


### PR DESCRIPTION
- If a username isn't found, emit a more appropriate error message that doesn't end in "success".
- The cmsd should be started as privilaged and set the fsuid to root to avoid permissions checks when looking for file existence.  Note that on shared filesystems, the CAP_DAC_READ_SEARCH is insufficient.
- On user switch failure, fail the IO operation.

This PR fixes the fact that files/paths must be world-readable to have the cmsd advertise their existence to the data federation.