### PR TITLE
Adding example config for cmsd

### DIFF
--- a/configs/60-osg-multiuser.cfg
+++ b/configs/60-osg-multiuser.cfg
@@ -1,8 +1,11 @@
 # Enable multiuser plugin. This makes XRootD to write the files with the
 # ownership of the user that authenticated to the server and not as the
 # 'xrootd' user
-ofs.osslib ++ libXrdMultiuser.so
-
+if named xrootd
+  ofs.osslib ++ libXrdMultiuser.so
+else
+  ofs.osslib libXrdMultiuser.so default
+fi
 
 # Enable the checksum wrapper
 ofs.ckslib * libXrdMultiuser.so


### PR DESCRIPTION
cmsd does not support stacked filesystem libraries, therefore we must have an 'if' around stacking so that it is stacked for xrootd, and not stacked for cmsd.