### PR TITLE
Add preliminary support for secondary GIDs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ add_definitions(-D_POSIX_C_SOURCE=200809L)
 
 include_directories(${XROOTD_INCLUDES} ${LIBCRYPTO_INCLUDE_DIRS} ${ZLIB_INCLUDE_DIRS})
 
-add_library(XrdMultiuser SHARED src/multiuser.cpp src/MultiuserFileSystem.cc src/XrdChecksum.cc src/XrdChecksumCalc.cc)
+add_library(XrdMultiuser SHARED src/multiuser.cpp src/MultiuserFileSystem.cc src/XrdChecksum.cc src/XrdChecksumCalc.cc src/GIDHandler.cc)
 target_link_libraries(XrdMultiuser -ldl ${CAP_LIB} ${XROOTD_UTILS_LIB} ${XROOTD_SERVER_LIB} ${LIBCRYPTO_LIBRARIES} ${ZLIB_LIBRARIES})
 set_target_properties(XrdMultiuser PROPERTIES OUTPUT_NAME "XrdMultiuser-${XROOTD_PLUGIN_VERSION}" SUFFIX ".so" LINK_FLAGS "-Wl,--version-script=${CMAKE_SOURCE_DIR}/configs/export-lib-symbols")
 

--- a/configs/cmsd-privileged@.service
+++ b/configs/cmsd-privileged@.service
@@ -16,8 +16,8 @@ LimitNOFILE=65536
 WorkingDirectory=/var/spool/xrootd
 
 # These provide cmsd with the ability to override read permissions to advertise file availability.
-CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_DAC_OVERRIDE
-Capabilities=CAP_SETGID+p CAP_SETUID+p
+CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_CHOWN CAP_DAC_OVERRIDE
+Capabilities=CAP_SETGID+p CAP_SETUID+p CAP_CHOWN+p
 
 [Install]
 RequiredBy=multi-user.target

--- a/configs/export-lib-symbols
+++ b/configs/export-lib-symbols
@@ -4,6 +4,7 @@ global:
   XrdOssAddStorageSystem*;
   XrdCksAdd2*;
   XrdCksInit*;
+  XrdSfsGetFileSystem*;
 
 local:
   *;

--- a/configs/xrootd-privileged@.service
+++ b/configs/xrootd-privileged@.service
@@ -16,8 +16,8 @@ LimitNOFILE=65536
 WorkingDirectory=/var/spool/xrootd
 
 # These provide xrootd with the ability to switch UIDs/GIDs for reading/writing files.
-CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_DAC_OVERRIDE
-Capabilities=CAP_SETGID+p CAP_SETUID+p
+CapabilityBoundingSet=CAP_SETUID CAP_SETGID CAP_CHOWN CAP_DAC_OVERRIDE
+Capabilities=CAP_SETGID+p CAP_SETUID+p CAP_CHOWN+p
 
 [Install]
 RequiredBy=multi-user.target

--- a/src/GIDHandler.cc
+++ b/src/GIDHandler.cc
@@ -1,0 +1,114 @@
+#include "GIDHandler.hh"
+#include "UserSentry.hh"
+#include "XrdOss/XrdOss.hh"
+#include "XrdSys/XrdSysError.hh"
+
+#include <grp.h>
+
+#include <algorithm>
+
+namespace {
+
+int RightStrip(const std::string &filename, size_t start_off)
+{
+    auto off = start_off;
+    while (true) {
+        if (filename[off] == '/') {
+            if (off == 0) {return -1;}
+            off -= 1;
+        } else {
+            break;
+        }
+    }
+    return off; 
+}
+
+bool GetParentDir(const std::string file, std::string &parent_output)
+{
+    std::string parent = file;
+    auto off = RightStrip(parent, parent.size() - 1);
+    if (off == -1) {return false;}
+
+    auto last_slash = parent.rfind('/', off);
+    if (last_slash == std::string::npos) {
+        return false;
+    }
+
+    off = RightStrip(parent, last_slash - 1);
+    if (off == -1) {
+        parent_output = "/";
+        return true;
+    }
+
+    parent_output = file.substr(0, off);
+    return true;
+}
+
+int DetermineGID_impl_stat(XrdOss &oss, XrdOucEnv &env, XrdSysError &log,
+    const std::string &username, int pgid, const std::string &path, struct stat &buff,
+    bool &sticky_gid, int &result);
+
+int DetermineGID_impl(XrdOss &oss, XrdOucEnv &env, XrdSysError &log,
+    const std::string &username, int pgid, const std::string &path, bool is_root, bool &sticky_gid)
+{
+    // First, invoke 'stat' on the file as root; if not present, we don't
+    // need to lookup any GIDs.  Note we have the stat done in a small helper
+    // function to avoid repetition.
+    struct stat buff;
+    int res, result;
+    if (is_root) {
+        res = DetermineGID_impl_stat(oss, env, log, username, pgid, path, buff, sticky_gid, result);
+    } else {
+        DacOverrideSentry sentry(log);
+        res = DetermineGID_impl_stat(oss, env, log, username, pgid, path, buff, sticky_gid, result);
+    }
+    if (res == -ENOENT) {return result;}
+    sticky_gid = (S_ISGID & buff.st_mode) == S_ISGID;
+
+    // We now know the group ownership and the mode.
+    // Before DetermineGID got called, we got a permission denied so we know the
+    // user- and owner-based access doesn't permit the operation to occur.  Hence,
+    // we should see if group-based access is allowed for one of the groups this user
+    // is a member of.
+    std::vector<gid_t> groups;
+    groups.resize(16, -1);
+    int actual_ngroups;
+    if (getgrouplist(username.c_str(), pgid, &groups[0], &actual_ngroups) == -1) {
+        groups.resize(actual_ngroups, -1);
+        if (getgrouplist(username.c_str(), pgid, &groups[0], &actual_ngroups) == -1) {
+            return -EIO;
+        }
+    }
+    groups.resize(actual_ngroups, -1);
+    const auto iter = std::find(groups.begin(), groups.end(), buff.st_gid);
+    if (iter != groups.end()) return buff.st_gid;
+    return -EACCES;
+}
+
+int DetermineGID_impl_stat(XrdOss &oss, XrdOucEnv &env, XrdSysError &log,
+    const std::string &username, int pgid, const std::string &path,
+    struct stat &buff, bool &sticky_gid, int &result)
+{
+    int res = oss.Stat(path.c_str(), &buff, 0, &env);
+    if (res == -ENOENT) {
+        // In this case, we need to look at the parent directory to see if it is
+        // readable by the desired user; recurse until we find a parent directory that exists.
+        std::string parent;
+        if (!GetParentDir(path, parent)) {
+            return -EINVAL;
+        }   
+        result = DetermineGID_impl(oss, env, log, username, pgid, parent, true, sticky_gid);
+    } else {
+        sticky_gid = false;
+    }
+    return res;
+}
+
+}
+
+
+int DetermineGID(XrdOss &oss, XrdOucEnv &env, XrdSysError &log, const std::string &username, int pgid, const std::string &path, bool &sticky_gid)
+{
+    sticky_gid = false;
+    return DetermineGID_impl(oss, env, log, username, pgid, path, false, sticky_gid);
+}

--- a/src/GIDHandler.cc
+++ b/src/GIDHandler.cc
@@ -40,7 +40,7 @@ bool GetParentDir(const std::string file, std::string &parent_output)
         return true;
     }
 
-    parent_output = file.substr(0, off);
+    parent_output = file.substr(0, off + 1);
     return true;
 }
 
@@ -72,7 +72,7 @@ int DetermineGID_impl(XrdOss &oss, XrdOucEnv &env, XrdSysError &log,
     // is a member of.
     std::vector<gid_t> groups;
     groups.resize(16, -1);
-    int actual_ngroups;
+    int actual_ngroups = 16;
     if (getgrouplist(username.c_str(), pgid, &groups[0], &actual_ngroups) == -1) {
         groups.resize(actual_ngroups, -1);
         if (getgrouplist(username.c_str(), pgid, &groups[0], &actual_ngroups) == -1) {

--- a/src/GIDHandler.hh
+++ b/src/GIDHandler.hh
@@ -1,0 +1,27 @@
+/**
+ * Handling of supplementary GIDs for XRootD multiuser.
+ *
+ * The multiuser plugin extensively utilizes the "filesystem UID/GID" within Linux.
+ * Unfortunately, this only allows for a *single* GID to be set.  These functions
+ * help emulate the POSIX logic around multiple GIDs to determine what GID should be
+ * used for a filesystem operation.
+ */
+#pragma once
+
+#include <string>
+
+// Forward dec'ls.
+class XrdOss;
+class XrdOucEnv;
+class XrdSysError;
+
+/**
+ * Given a username and a path, determine which supplemental GID should
+ * be used to access the path as the filesystem GID.
+ *
+ * Returns a non-negative GID on success; on failure, returns the -errno
+ * that should be used for the filesystem call.
+ */
+int DetermineGID(XrdOss &oss, XrdOucEnv &env, XrdSysError &log,
+                 const std::string &username, int pgid, const std::string &path,
+                 bool &sticky_gid);

--- a/src/MultiuserFileSystem.hh
+++ b/src/MultiuserFileSystem.hh
@@ -62,6 +62,7 @@ public:
     int       Unlink(const char *path, int Opts=0, XrdOucEnv *env=0);
     int       Lfn2Pfn(const char *Path, char *buff, int blen);
     const char       *Lfn2Pfn(const char *Path, char *buff, int blen, int &rc);
+    XrdOss   *GetWrappedOss() {return m_oss;}
 
 private:
     mode_t m_umask_mode;


### PR DESCRIPTION
This has a functional setup for uploading, downloading, and making directories where secondary GIDs are needed for access.

Current limitations:
- I did not go through the entire API (e.g., rmdir won't work correctly) as I wanted to get this out the door for testing at Chicago.  If all goes well, we can flesh out more in the future.
- This is only going to work as desired for directories with setgid enabled.

Toward the second item: we can only open a file with a single filesystem GID.  If multiple GIDs are needed to walk the entire directory tree (e.g., `/tmp/foo` is only readable by group A and `/tmp/foo/bar` is only readable by group B) then this approach would fail.

A complete solution would require stepping up the directory tree using `openat` (potentially switching the FS GID at each layer).  That's a lot more complex than the current approach -- and, to boot, the XRootD API doesn't wrap the `*at` functions.  Hence, you'd need to create an object, run `Opendir`, get the underlying file descriptor (see the current `Mkdir` for an example) at each step of the way; basically, one would need to abuse the existing API and wrap it with a complete new one.

So, this solution is not complete; however, in all the use cases, we plan to only use `setgid` directories ... meaning that there's no current use case for the missing functionality and I'm OK to come back later.