### PR TITLE
Switch uid/gid for Readdir() calls

### DIFF
--- a/src/MultiuserDirectory.hh
+++ b/src/MultiuserDirectory.hh
@@ -30,6 +30,8 @@ public:
 
     int Readdir(char *buff, int blen) 
     {
+        UserSentry sentry(m_client, m_log);
+        if (!sentry.IsValid()) {return -EACCES;}
         return m_wrappedDir->Readdir(buff, blen);
     }
 


### PR DESCRIPTION
stat()'ing entries in directories may require uid/gid switching when permissions are limited.

Fixes #49 