### PR TITLE
Require XC_ENABLE_MULTIUSER to be set to enable multiuser

### DIFF
--- a/configs/60-osg-multiuser.cfg
+++ b/configs/60-osg-multiuser.cfg
@@ -1,18 +1,20 @@
 # Enable multiuser plugin. This makes XRootD to write the files with the
 # ownership of the user that authenticated to the server and not as the
 # 'xrootd' user
-if exec xrootd
+if exec xrootd && defined ?~XC_ENABLE_MULTIUSER
   ofs.osslib ++ libXrdMultiuser.so
-else
+else if defined ?~XC_ENABLE_MULTIUSER
   ofs.osslib libXrdMultiuser.so default
 fi
 
-# Enable the checksum wrapper
-ofs.ckslib * libXrdMultiuser.so
+if defined ?~XC_ENABLE_MULTIUSER
+  # Enable the checksum wrapper
+  ofs.ckslib * libXrdMultiuser.so
 
-xrootd.chksum max 2 md5 adler32 crc32
+  xrootd.chksum max 2 md5 adler32 crc32
 
-# The checksum plugin that is included in the multiuser can also
-# checksum while it is writing a file.  To turn this on, uncomment the
-# following line:
-# multiuser.checksumonwrite on
+  # The checksum plugin that is included in the multiuser can also
+  # checksum while it is writing a file.  To turn this on, uncomment the
+  # following line:
+  # multiuser.checksumonwrite on
+fi

--- a/configs/60-osg-multiuser.cfg
+++ b/configs/60-osg-multiuser.cfg
@@ -1,7 +1,7 @@
 # Enable multiuser plugin. This makes XRootD to write the files with the
 # ownership of the user that authenticated to the server and not as the
 # 'xrootd' user
-if exec xrootd && defined ?~XC_ENABLE_MULTIUSER
+if defined ?~XC_ENABLE_MULTIUSER && exec xrootd 
   ofs.osslib ++ libXrdMultiuser.so
 else if defined ?~XC_ENABLE_MULTIUSER
   ofs.osslib libXrdMultiuser.so default

--- a/configs/cmsd-privileged@.service
+++ b/configs/cmsd-privileged@.service
@@ -8,6 +8,7 @@ After=network-online.target
 [Service]
 # Note "-R xrootd" here instructs xrootd to drop privileges to the xrootd Unix user.
 ExecStart=/usr/bin/cmsd -l /var/log/xrootd/cmsd.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /var/run/xrootd/cmsd-%i.pid -n %i -R xrootd
+Environment=XC_ENABLE_MULTIUSER=1
 Type=simple
 Restart=on-abort
 RestartSec=0

--- a/configs/xrootd-privileged@.service
+++ b/configs/xrootd-privileged@.service
@@ -8,6 +8,7 @@ After=network-online.target
 [Service]
 # Note "-R xrootd" here instructs xrootd to drop privileges to the xrootd Unix user.
 ExecStart=/usr/bin/xrootd -l /var/log/xrootd/xrootd.log -c /etc/xrootd/xrootd-%i.cfg -k fifo -s /var/run/xrootd/xrootd-%i.pid -n %i -R xrootd
+Environment=XC_ENABLE_MULTIUSER=1
 Type=simple
 Restart=on-abort
 RestartSec=0


### PR DESCRIPTION
SOFTWARE-5481.  Multiuser causes xrootd to fail to start if we don't have CAP_SETUID and CAP_SETGID; allow enabling/disabling it via an environment variable. The *-privileged.service files will set that environment variable.