### PR TITLE
Log that it's xrootd-multiuser denying access, not the file system

### DIFF
--- a/src/UserSentry.hh
+++ b/src/UserSentry.hh
@@ -152,22 +152,18 @@ public:
         } while (1);
         if (result == nullptr) {
             if (retval) {  // There's an actual error in the lookup.
-                m_log.Emsg("UserSentry", "Failure when looking up UID for username", username.c_str(), strerror(retval));
-                m_log.Emsg("UserSentry", "Multiuser denying access");
+                m_log.Emsg("UserSentry", "Multiuser denying access: Failure when looking up UID for username", username.c_str(), strerror(retval));
             } else {  // Username doesn't exist.
-                m_log.Emsg("UserSentry", "XRootD mapped request to username that does not exist:", username.c_str());
-                m_log.Emsg("UserSentry", "Multiuser denying access");
+                m_log.Emsg("UserSentry", "Multiuser denying access: XRootD mapped request to username that does not exist:", username.c_str());
             }
             return;
         }
         if (pwd.pw_uid < g_minimum_uid) {
-            m_log.Emsg("UserSentry", "Username", username.c_str(), "maps to a system UID; rejecting lookup");
-            m_log.Emsg("UserSentry", "Multiuser denying access");
+            m_log.Emsg("UserSentry", "Multiuser denying access: Username", username.c_str(), "maps to a system UID; rejecting lookup");
             return;
         }
         if (pwd.pw_gid < g_minimum_gid) {
-            m_log.Emsg("UserSentry", "Username", username.c_str(), "maps to a system GID; rejecting lookup");
-            m_log.Emsg("UserSentry", "Multiuser denying access");
+            m_log.Emsg("UserSentry", "Multiuser denying access: Username", username.c_str(), "maps to a system GID; rejecting lookup");
             return;
         }
 
@@ -185,8 +181,7 @@ public:
             break;
         } while (1);
         if (-1 == retval) {
-            m_log.Emsg("UserSentry", "Failure when looking up supplementary groups for username", username.c_str());
-            m_log.Emsg("UserSentry", "Multiuser denying access");
+            m_log.Emsg("UserSentry", "Multiuser denying access: Failure when looking up supplementary groups for username", username.c_str());
             return;
         }
 
@@ -197,8 +192,7 @@ public:
         m_log.Emsg("UserSentry", "Switching FS uid for user", username.c_str());
         m_orig_uid = setfsuid(result->pw_uid);
         if (m_orig_uid < 0) {
-            m_log.Emsg("UserSentry", "Failed to switch FS uid for user", username.c_str());
-            m_log.Emsg("UserSentry", "Multiuser denying access");
+            m_log.Emsg("UserSentry", "Multiuser denying access: Failed to switch FS uid for user", username.c_str());
             return;
         }
         m_orig_gid = setfsgid(result->pw_gid);

--- a/src/UserSentry.hh
+++ b/src/UserSentry.hh
@@ -153,17 +153,21 @@ public:
         if (result == nullptr) {
             if (retval) {  // There's an actual error in the lookup.
                 m_log.Emsg("UserSentry", "Failure when looking up UID for username", username.c_str(), strerror(retval));
+                m_log.Emsg("UserSentry", "Multiuser denying access");
             } else {  // Username doesn't exist.
                 m_log.Emsg("UserSentry", "XRootD mapped request to username that does not exist:", username.c_str());
+                m_log.Emsg("UserSentry", "Multiuser denying access");
             }
             return;
         }
         if (pwd.pw_uid < g_minimum_uid) {
             m_log.Emsg("UserSentry", "Username", username.c_str(), "maps to a system UID; rejecting lookup");
+            m_log.Emsg("UserSentry", "Multiuser denying access");
             return;
         }
         if (pwd.pw_gid < g_minimum_gid) {
             m_log.Emsg("UserSentry", "Username", username.c_str(), "maps to a system GID; rejecting lookup");
+            m_log.Emsg("UserSentry", "Multiuser denying access");
             return;
         }
 
@@ -182,6 +186,7 @@ public:
         } while (1);
         if (-1 == retval) {
             m_log.Emsg("UserSentry", "Failure when looking up supplementary groups for username", username.c_str());
+            m_log.Emsg("UserSentry", "Multiuser denying access");
             return;
         }
 
@@ -193,6 +198,7 @@ public:
         m_orig_uid = setfsuid(result->pw_uid);
         if (m_orig_uid < 0) {
             m_log.Emsg("UserSentry", "Failed to switch FS uid for user", username.c_str());
+            m_log.Emsg("UserSentry", "Multiuser denying access");
             return;
         }
         m_orig_gid = setfsgid(result->pw_gid);


### PR DESCRIPTION
Since the various operations just return -EACCES when xrootd-multiuser couldn't change users (or groups), it's confusing whether access is denied by the file system, or by xrootd-multiuser itself.  Make it explicit via a log message.