### PR TITLE
When checksums are missing, limit the calculations to checksums enabled in the config

### DIFF
--- a/src/XrdChecksum.cc
+++ b/src/XrdChecksum.cc
@@ -63,7 +63,9 @@ int        ChecksumManager::Calc( const char *lfn, XrdCksData &Cks, int doSet)
     int return_digest = 0;
     if (doSet)
     {
-        digests = ChecksumManager::ALL;
+        // doSet indicates that the new checksum value must replace any existing xattrs.
+        // Calculate the enabled checksums (not necessarily all known to the plugin).
+        digests = g_multisuer_oss.m_digests;
     }
     if (!strncasecmp(Cks.Name, "md5", Cks.NameSize))
     {


### PR DESCRIPTION
When a file is missing checksum xattrs, the plugin calculates all known checksums (not just the ones enabled), which adds CPU overhead.

This problem is made worse if the file is not writable to the current client, so the checksums xattrs cannot be written. And later accesses repeat the checksum calculation.

One drawback of this change is that it won't overwrite other checksum attributes that might be present. Perhaps that can be considered out of scope.

Opening as a draft for comment.